### PR TITLE
Expand use of dict get method to simplify code

### DIFF
--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -475,6 +475,7 @@ class HTML2Text(html.parser.HTMLParser):
                             self.maybe_automatic_link = None
                         if self.inline_links:
                             title = a.get("title", "")
+                            assert title is not None
                             title = escape_md(title)
                             link_url(self, a["href"], title)
                         else:
@@ -493,6 +494,7 @@ class HTML2Text(html.parser.HTMLParser):
                 if not self.images_to_alt:
                     attrs["href"] = img_attrs_src
                 alt = attrs.get("alt", self.default_image_alt)
+                assert alt is not None
 
                 # If we have images_with_size, write raw html including width,
                 # height, and alt attributes

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -498,7 +498,10 @@ class HTML2Text(html.parser.HTMLParser):
                 # height, and alt attributes
                 img_attrs_width = attrs.get("width")
                 img_attrs_height = attrs.get("height")
-                if self.images_as_html or self.images_with_size:
+                if self.images_as_html or (
+                    self.images_with_size
+                    and not (not img_attrs_width and not img_attrs_height)
+                ):
                     self.o("<img src='" + img_attrs_src + "' ")
                     if img_attrs_width:
                         self.o("width='" + img_attrs_width + "' ")

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -201,14 +201,16 @@ class HTML2Text(html.parser.HTMLParser):
         self.a list. If the set of attributes is not found, returns None
         :rtype: int
         """
-        attrs_href = attrs.get("href") 
+        attrs_href = attrs.get("href")
         if attrs_href is None:
             return None
 
         attrs_title = attrs.get("title")
         for i, a in enumerate(self.a):
-            if ((attrs_href == a.attrs.get("href")) and
-                (attrs_title == a.attrs.get("title"))):
+            if (
+                (attrs_href == a.attrs.get("href"))
+                and (attrs_title == a.attrs.get("title"))
+            ):
                 return i
 
         return None
@@ -499,8 +501,8 @@ class HTML2Text(html.parser.HTMLParser):
                 img_attrs_width = attrs.get("width")
                 img_attrs_height = attrs.get("height")
                 if self.images_as_html or (
-                    self.images_with_size and
-                    not (img_attrs_width is img_attrs_height is None)
+                    self.images_with_size
+                    and not (img_attrs_width is img_attrs_height is None)
                 ):
                     self.o("<img src='" + img_attrs_src + "' ")
                     if img_attrs_width is not None:

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -207,9 +207,8 @@ class HTML2Text(html.parser.HTMLParser):
 
         attrs_title = attrs.get("title")
         for i, a in enumerate(self.a):
-            if (
-                (attrs_href == a.attrs.get("href"))
-                and (attrs_title == a.attrs.get("title"))
+            if (attrs_href == a.attrs.get("href")) and (
+                attrs_title == a.attrs.get("title")
             ):
                 return i
 
@@ -453,9 +452,8 @@ class HTML2Text(html.parser.HTMLParser):
         if tag == "a" and not self.ignore_links:
             if start:
                 attrs_href = attrs.get("href")
-                if (
-                    attrs_href is None
-                    or (self.skip_internal_links and attrs_href.startswith("#"))
+                if attrs_href is None or (
+                    self.skip_internal_links and attrs_href.startswith("#")
                 ):
                     self.astack.append(None)
                 else:

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -537,7 +537,8 @@ class HTML2Text(html.parser.HTMLParser):
                 else:
                     self.o("![" + alt + "]")
                     if self.inline_links:
-                        href = attrs.get("href", "")
+                        href = attrs.get("href")
+                        href = "" if href is None else href
                         self.o(
                             "(" + escape_md(urlparse.urljoin(self.baseurl, href)) + ")"
                         )

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -537,7 +537,7 @@ class HTML2Text(html.parser.HTMLParser):
                 else:
                     self.o("![" + alt + "]")
                     if self.inline_links:
-                        href = attrs.get("href", "")
+                        href = attrs.get("href") or ""
                         self.o(
                             "(" + escape_md(urlparse.urljoin(self.baseurl, href)) + ")"
                         )

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -474,9 +474,8 @@ class HTML2Text(html.parser.HTMLParser):
                             self.empty_link = False
                             self.maybe_automatic_link = None
                         if self.inline_links:
-                            title = a.get("title", "")
-                            assert title is not None
-                            title = escape_md(title)
+                            title = a.get("title")
+                            title = "" if title is None else escape_md(title)
                             link_url(self, a["href"], title)
                         else:
                             i = self.previousIndex(a)
@@ -494,35 +493,33 @@ class HTML2Text(html.parser.HTMLParser):
                 if not self.images_to_alt:
                     attrs["href"] = img_attrs_src
                 alt = attrs.get("alt", self.default_image_alt)
-                assert alt is not None
 
                 # If we have images_with_size, write raw html including width,
                 # height, and alt attributes
                 img_attrs_width = attrs.get("width")
                 img_attrs_height = attrs.get("height")
-                if self.images_as_html or (
-                    self.images_with_size
-                    and not (img_attrs_width is img_attrs_height is None)
-                ):
+                if self.images_as_html or self.images_with_size:
                     self.o("<img src='" + img_attrs_src + "' ")
-                    if img_attrs_width is not None:
+                    if img_attrs_width:
                         self.o("width='" + img_attrs_width + "' ")
-                    if img_attrs_height is not None:
+                    if img_attrs_height:
                         self.o("height='" + img_attrs_height + "' ")
                     if alt:
                         self.o("alt='" + alt + "' ")
                     self.o("/>")
                     return
 
+                alt = "" if alt is None else escape_md(alt)
+
                 # If we have a link to create, output the start
                 if self.maybe_automatic_link is not None:
                     href = self.maybe_automatic_link
                     if (
                         self.images_to_alt
-                        and escape_md(alt) == href
+                        and alt == href
                         and self.absolute_url_matcher.match(href)
                     ):
-                        self.o("<" + escape_md(alt) + ">")
+                        self.o("<" + alt + ">")
                         self.empty_link = False
                         return
                     else:
@@ -533,9 +530,9 @@ class HTML2Text(html.parser.HTMLParser):
                 # If we have images_to_alt, we discard the image itself,
                 # considering only the alt text.
                 if self.images_to_alt:
-                    self.o(escape_md(alt))
+                    self.o(alt)
                 else:
-                    self.o("![" + escape_md(alt) + "]")
+                    self.o("![" + alt + "]")
                     if self.inline_links:
                         href = attrs.get("href", "")
                         self.o(

--- a/html2text/__init__.py
+++ b/html2text/__init__.py
@@ -537,8 +537,7 @@ class HTML2Text(html.parser.HTMLParser):
                 else:
                     self.o("![" + alt + "]")
                     if self.inline_links:
-                        href = attrs.get("href")
-                        href = "" if href is None else href
+                        href = attrs.get("href", "")
                         self.o(
                             "(" + escape_md(urlparse.urljoin(self.baseurl, href)) + ")"
                         )


### PR DESCRIPTION
In the code, there was often both a check for whether a certain key was in a dict and a conditional access of the corresponding value. This can be elegantly combined in a single call to the dict get method, whose default value if the key is not in the dict is None.
Using the get method instead of the check and conditional access makes it possible to simplify the code in various places.
This is done so in this patch.